### PR TITLE
feat: LLM Runtime Integration modifier (L0-L4)

### DIFF
--- a/.claude/skills/risk-assess/SKILL.md
+++ b/.claude/skills/risk-assess/SKILL.md
@@ -145,6 +145,37 @@ Blast radius is nearly impossible to auto-detect. Note any hints:
 
 Flag that user confirmation is **required**.
 
+### 2f. LLM Runtime Integration Detection
+
+Grep for LLM SDK imports and agentic patterns using the patterns in the
+`LLM Runtime Integration` section of `.claude/skills/shared/risk-model.md`.
+
+Report findings with evidence:
+
+```
+LLM Runtime scan for {module}:
+  LLM SDK imports: 3 files
+    src/chat/client.ts:1 — imports "openai"
+    src/summarize.ts:2 — imports "@anthropic-ai/sdk"
+  Generative patterns (L2+): 2 files
+    src/chat/client.ts:14 — matches "messages.create"
+  Tool use / agentic patterns (L3+): 0 matches
+  Code-execution sandbox (L4): 0 matches
+  → Auto-detected hint: L2 (Generative)
+```
+
+If **no** LLM imports are found:
+
+```
+LLM Runtime scan for {module}:
+  No LLM SDK imports found.
+  → Auto-detected hint: L0 (No LLM)
+```
+
+Auto-detection produces only a **hint** — the user must always confirm the
+level explicitly in Step 3. A library import alone is ambiguous (could be
+test code, data-science notebooks, build tooling, or production).
+
 ---
 
 ## Step 3 — Interactive Confirmation
@@ -203,6 +234,34 @@ Data Sensitivity: Auto-detected score 2 (General PII)
   [Keep 2] / [Upgrade to 3: Sensitive PII] / [Upgrade to 4: PHI/PCI]
 ```
 
+### 3d. LLM Runtime Integration Confirmation (ALWAYS ask)
+
+Auto-detection produces only a hint — **always** ask the user to confirm,
+even if L0 was detected (the user may know about planned future LLM use).
+
+Present the hint with evidence, then ask:
+
+```
+LLM Runtime Integration for {module}:
+  Auto-detected hint: L2 (Generative)
+  Evidence: openai + @anthropic-ai/sdk imported, messages.create pattern found in src/chat/client.ts
+
+  How does this module use LLMs at runtime?
+  [0] No LLM — classical software, no LLM at runtime
+  [1] Classify — passive use: sentiment, intent, embeddings
+  [2] Generate — generative output: chat, summaries
+  [3] Tool Use — function calling, LLM triggers actions
+  [4] Agentic — autonomous loops, code execution, self-modification
+
+  Suggested: [2]
+```
+
+Remind the user of the tier implications before they answer:
+
+> **Note:** L3 forces at least Tier 3, L4 forces at least Tier 4, regardless
+> of the code dimensions. A coding agent that could run `rm -rf` is
+> safety-critical by definition.
+
 ---
 
 ## Step 4 — Tier Calculation and Output
@@ -210,11 +269,14 @@ Data Sensitivity: Auto-detected score 2 (General PII)
 ### 4a. Calculate Tier
 
 ```
-Tier = max(codeType, language, deployment, data, blastRadius)
-Mapping: max <= 1 → Tier 1, max <= 2 → Tier 2, max <= 3 → Tier 3, max = 4 → Tier 4
+base     = max(codeType, language, deployment, data, blastRadius)
+baseTier = base <= 1 ? 1 : base <= 2 ? 2 : base <= 3 ? 3 : 4
+floor    = llmRuntimeLevel >= 4 ? 4 : llmRuntimeLevel >= 3 ? 3 : 1
+tier     = max(baseTier, floor)
 ```
 
-Present the result:
+Present the result. If the LLM Runtime modifier **lifted** the tier
+above the base, make that explicit:
 
 ```
 {module} Risk Assessment:
@@ -223,8 +285,24 @@ Present the result:
   Deployment:       2 (Public-facing app)
   Data Sensitivity: 2 (General PII)
   Blast Radius:     1 (Performance / DoS)
+  LLM Runtime:      L0 (No LLM)
 
   → Tier 3 — determined by Code Type = 3
+```
+
+Example with modifier lift:
+
+```
+{module} Risk Assessment:
+  Code Type:        2 (Business Logic)
+  Language:         2 (Dynamically typed)
+  Deployment:       2 (Public-facing app)
+  Data Sensitivity: 1 (Internal business data)
+  Blast Radius:     2 (Data loss recoverable)
+  LLM Runtime:      L4 (Agentic)
+
+  Base Tier: 2 — Moderate
+  → Tier 4 — lifted from Tier 2 by LLM Runtime L4 (Agentic)
 ```
 
 ### 4b. Scan Existing Mitigations

--- a/.claude/skills/risk-mitigate/SKILL.md
+++ b/.claude/skills/risk-mitigate/SKILL.md
@@ -18,14 +18,15 @@ Read the shared risk model at `.claude/skills/shared/risk-model.md` for all meas
    > No Risk Radar Assessment found in CLAUDE.md. Please run `/risk-assess` first.
 4. If found, parse every `### Module: {name}` subsection. For each module extract:
    - The five dimension scores (codeType, language, deployment, data, blastRadius)
+   - The **LLM Runtime Integration** level (L0–L4), if present (default L0 for legacy assessments)
    - The overall **Tier** (1–4)
 5. Print a summary table:
 
 ```
 Found N module(s) with risk assessments:
-| Module | Tier | Highest Dimension |
-|--------|------|-------------------|
-| ...    | ...  | ...               |
+| Module | Tier | Highest Dimension | LLM Runtime |
+|--------|------|-------------------|-------------|
+| ...    | ...  | ...               | L{N}        |
 ```
 
 ---
@@ -115,6 +116,54 @@ After the table, summarize:
 - Already present: Y
 - Missing: Z
 - Completion: Y/X (percentage)
+
+### 3b. LLM Runtime Callout (L3+ modules only)
+
+If any module has `llmRuntimeLevel >= 3`, display a **callout** before moving
+to implementation, making it explicit that our mitigation catalog is
+**insufficient** for runtime LLM risks:
+
+```
+⚠️  {module} has LLM Runtime Integration L{N} ({name})
+
+The mitigations listed above cover build-time risks (how the code was
+written). Your runtime LLM use introduces a qualitatively different risk
+class — prompt injection, unauthorized tool calls, agentic runaway — that
+this framework does not deeply cover.
+
+For these risks, defer to specialized frameworks:
+
+  • OWASP LLM Top 10
+    https://owasp.org/www-project-top-10-for-large-language-model-applications/
+  • Palo Alto Unit 42 SHIELD
+    https://unit42.paloaltonetworks.com/securing-vibe-coding-tools/
+  • Aikido VCAL
+    https://www.aikido.dev/blog/vibe-coding-security
+  • Google SAIF
+    https://saif.google/secure-ai-framework
+
+Recommended runtime mitigations (not installable via this skill):
+  - Prompt injection detection and input sanitization
+  - Tool allow-list / deny-list with least-privilege function calling
+  - Output filtering (PII redaction, unsafe content detection)
+  - Sandbox for code execution (e2b, Firecracker, gVisor)
+  - Rate limiting and cost caps per user/session
+  - Audit logging of all tool calls with prompt provenance
+  - Human-in-the-loop confirmation for destructive actions
+```
+
+Ask the user:
+
+```
+Would you like to track these runtime mitigations in CLAUDE.md as
+pending items? [y/N]
+```
+
+If yes, add a new table `### LLM Runtime Mitigations: {module-name} (L{N})`
+to CLAUDE.md with the recommended runtime mitigations as `Pending`, plus
+links to the source framework for each. The skill **does not** install
+these tools — they require architectural decisions that belong with the
+user, not an automated skill.
 
 ---
 

--- a/.claude/skills/shared/risk-model.md
+++ b/.claude/skills/shared/risk-model.md
@@ -3,11 +3,18 @@
 ## Tier Calculation
 
 ```
-Tier = max(codeType, language, deployment, data, blastRadius)
-Mapping: max <= 1 → Tier 1, max <= 2 → Tier 2, max <= 3 → Tier 3, max = 4 → Tier 4
+base = max(codeType, language, deployment, data, blastRadius)
+baseTier = base <= 1 ? 1 : base <= 2 ? 2 : base <= 3 ? 3 : 4
+
+# LLM Runtime Integration modifier (cross-cutting):
+floor = llmRuntimeLevel >= 4 ? 4 : llmRuntimeLevel >= 3 ? 3 : 1
+
+tier = max(baseTier, floor)
 ```
 
 Tiers are **cumulative**: Tier N includes all mitigations from Tier 1 through N-1.
+
+The **LLM Runtime Integration** modifier is separate from the 5 code dimensions — it describes what the software does _at runtime_, not how the code was written. See the dedicated section below.
 
 ---
 
@@ -15,53 +22,136 @@ Tiers are **cumulative**: Tier N includes all mitigations from Tier 1 through N-
 
 ### 1. Code Type (`codeType`)
 
-| Score | Level | Examples |
-|-------|-------|---------|
-| 0 | UI / CSS / Docs | Styling, static pages, documentation |
-| 1 | Build Scripts / Tests | CI configs, test files, Makefiles |
-| 2 | Business Logic | Domain services, data processing, validation |
-| 3 | API / DB Queries | REST/GraphQL endpoints, SQL, ORM code |
-| 4 | Auth / Security / Crypto | Authentication, encryption, access control |
+| Score | Level                    | Examples                                     |
+| ----- | ------------------------ | -------------------------------------------- |
+| 0     | UI / CSS / Docs          | Styling, static pages, documentation         |
+| 1     | Build Scripts / Tests    | CI configs, test files, Makefiles            |
+| 2     | Business Logic           | Domain services, data processing, validation |
+| 3     | API / DB Queries         | REST/GraphQL endpoints, SQL, ORM code        |
+| 4     | Auth / Security / Crypto | Authentication, encryption, access control   |
 
 ### 2. Language Safety (`language`)
 
-| Score | Level | Languages |
-|-------|-------|-----------|
-| 0 | Static + Memory-safe | Rust |
-| 1 | Statically typed | TypeScript, Java, Go, Kotlin, Scala, Swift |
-| 2 | Dynamically typed | Python, JavaScript, Ruby, PHP, Lua, Elixir |
-| 3 | Memory-unsafe managed | C# with `unsafe` blocks |
-| 4 | Memory-unsafe | C, C++, Assembly |
+| Score | Level                 | Languages                                  |
+| ----- | --------------------- | ------------------------------------------ |
+| 0     | Static + Memory-safe  | Rust                                       |
+| 1     | Statically typed      | TypeScript, Java, Go, Kotlin, Scala, Swift |
+| 2     | Dynamically typed     | Python, JavaScript, Ruby, PHP, Lua, Elixir |
+| 3     | Memory-unsafe managed | C# with `unsafe` blocks                    |
+| 4     | Memory-unsafe         | C, C++, Assembly                           |
 
 ### 3. Deployment Context (`deployment`)
 
-| Score | Level | Examples |
-|-------|-------|---------|
-| 0 | Personal / Prototype | Local tools, learning projects |
-| 1 | Internal tool | Company-internal dashboards, admin tools |
-| 2 | Public-facing app | SaaS, public APIs, mobile apps |
-| 3 | Regulated system | HIPAA, PCI-DSS, SOC2, GDPR-critical |
-| 4 | Safety-critical | Avionics, medical devices, automotive |
+| Score | Level                | Examples                                 |
+| ----- | -------------------- | ---------------------------------------- |
+| 0     | Personal / Prototype | Local tools, learning projects           |
+| 1     | Internal tool        | Company-internal dashboards, admin tools |
+| 2     | Public-facing app    | SaaS, public APIs, mobile apps           |
+| 3     | Regulated system     | HIPAA, PCI-DSS, SOC2, GDPR-critical      |
+| 4     | Safety-critical      | Avionics, medical devices, automotive    |
 
 ### 4. Data Sensitivity (`data`)
 
-| Score | Level | Examples |
-|-------|-------|---------|
-| 0 | Public data | Open datasets, public content |
-| 1 | Internal business data | Revenue figures, internal docs |
-| 2 | General PII | Name, email, phone, address |
-| 3 | Sensitive PII | SSN, biometrics, passport numbers |
-| 4 | PHI / PCI | Medical records (HIPAA), credit cards (PCI) |
+| Score | Level                  | Examples                                    |
+| ----- | ---------------------- | ------------------------------------------- |
+| 0     | Public data            | Open datasets, public content               |
+| 1     | Internal business data | Revenue figures, internal docs              |
+| 2     | General PII            | Name, email, phone, address                 |
+| 3     | Sensitive PII          | SSN, biometrics, passport numbers           |
+| 4     | PHI / PCI              | Medical records (HIPAA), credit cards (PCI) |
 
 ### 5. Blast Radius (`blastRadius`)
 
-| Score | Level | Examples |
-|-------|-------|---------|
-| 0 | Cosmetic / Tech debt | UI glitches, code smell |
-| 1 | Performance / DoS | Slowdowns, service unavailability |
-| 2 | Data loss (recoverable) | Lost data restorable from backups |
-| 3 | Systemic breach | Unrecoverable data exposure |
-| 4 | Safety (life & limb) | Physical harm, loss of life |
+| Score | Level                   | Examples                          |
+| ----- | ----------------------- | --------------------------------- |
+| 0     | Cosmetic / Tech debt    | UI glitches, code smell           |
+| 1     | Performance / DoS       | Slowdowns, service unavailability |
+| 2     | Data loss (recoverable) | Lost data restorable from backups |
+| 3     | Systemic breach         | Unrecoverable data exposure       |
+| 4     | Safety (life & limb)    | Physical harm, loss of life       |
+
+---
+
+## LLM Runtime Integration (`llmRuntimeLevel`, 0–4)
+
+Cross-cutting modifier describing how the software uses LLMs **at runtime** (not how the code was written). This captures a qualitatively different risk profile from LLM-generated code:
+
+- **LLM code** is a build-time problem → mitigated by linters, review, SAST
+- **LLM runtime** is an operational problem → mitigated by sandboxing, tool whitelists, output filters, prompt injection detection
+
+### Escalation ladder
+
+| Level | Name     | Description                                         | Primary risks                                            |
+| ----- | -------- | --------------------------------------------------- | -------------------------------------------------------- |
+| 0     | No LLM   | Classical software, no LLM at runtime               | —                                                        |
+| 1     | Classify | Passive: sentiment, intent, embeddings              | Misclassification, bias                                  |
+| 2     | Generate | Generative output: chat, summaries                  | Hallucination, prompt injection on content               |
+| 3     | Tool Use | Function calling, LLM triggers actions              | Prompt injection → unauthorized actions, jailbreaks      |
+| 4     | Agentic  | Autonomous loops, code execution, self-modification | Prompt injection → RCE, data exfiltration, runaway costs |
+
+### Tier Multiplier (hard floor)
+
+- **L3** → Tier floor 3 (minimum Tier 3 regardless of code dimensions)
+- **L4** → Tier floor 4 (minimum Tier 4 regardless of code dimensions)
+- L0–L2 do not raise the tier floor
+
+Rationale: A coding agent that can execute `rm -rf` is safety-critical by definition, even if the surface blast radius seems small. Agentic systems introduce failure classes (prompt injection → RCE) that classical reviews do not catch.
+
+### Auto-Detection Patterns
+
+Auto-detection only produces **hints** — the user must always confirm the level explicitly, because library presence alone is ambiguous (a library can be used for testing, data-science notebooks, or production).
+
+**LLM SDK imports (any level ≥ L1):**
+
+```
+\b(from\s+anthropic|import\s+anthropic)\b
+\b(from\s+openai|import\s+openai)\b
+\b(@anthropic-ai/sdk|@anthropic-ai/claude-agent-sdk)
+\b(@ai-sdk/(openai|anthropic|google|mistral|cohere))
+\b(langchain|langgraph|llama[-_]?index|llamaindex)\b
+\b(ollama|together|groq|replicate|cohere|mistralai|bedrock-runtime)\b
+\b(@google/generative-ai|google-generativeai|vertexai)\b
+```
+
+**Agentic / Tool Use indicators (hints toward L3–L4):**
+
+```
+\b(tool_use|tool_choice|function_call|functions\s*[:=])\b
+\b(tools\s*[:=]\s*\[)
+\b(agent|agentic|autonomous|react_?agent|tool_?agent)\b
+\b(execute_?command|shell_?exec|run_?code|code_?interpreter)\b
+\b(langchain\.(agents|tools)|langgraph)\b
+```
+
+**Code-execution sandbox libraries (strong L4 indicator):**
+
+```
+\b(e2b|firecracker|gvisor|deno-sandbox|pyodide)\b
+\b(docker-py|dockerode.*exec|subprocess.*llm)\b
+```
+
+### Confidence
+
+| Detection signal                                            | Confidence | User confirmation                                    |
+| ----------------------------------------------------------- | ---------- | ---------------------------------------------------- |
+| LLM SDK imported                                            | 0.6 (L1+)  | **Always** — library could be for tests/data-science |
+| Generative patterns (`messages.create`, `chat.completions`) | 0.75 (L2+) | **Always**                                           |
+| Tool use / function calling patterns                        | 0.7 (L3+)  | **Always**                                           |
+| Sandbox/code-execution libraries                            | 0.85 (L4)  | **Always**                                           |
+| No LLM imports found                                        | 0.9 (L0)   | Only if user mentions LLM use                        |
+
+### CLAUDE.md output
+
+LLM Runtime level is stored as part of the per-module assessment:
+
+```markdown
+### Module: {module-name}
+
+**LLM Runtime Integration:** L{N} ({name}) — {evidence or "user input"}
+
+| Dimension | Score | Level | Evidence |
+...
+```
 
 ---
 
@@ -71,26 +161,26 @@ Tiers are **cumulative**: Tier N includes all mitigations from Tier 1 through N-
 
 Check these files for explicit module declarations:
 
-| Config File | Parse Field | Module = |
-|-------------|-------------|----------|
-| `pnpm-workspace.yaml` | `packages:` array | Each resolved glob path |
-| `package.json` (root) | `"workspaces"` field | Each resolved glob path |
-| `lerna.json` | `"packages"` array | Each resolved path |
-| `Cargo.toml` (root) | `[workspace] members` | Each member path |
-| `settings.gradle(.kts)` | `include(...)` | Each subproject dir |
-| `pom.xml` (root) | `<modules>` elements | Each module dir |
-| `go.work` | `use (...)` | Each module dir |
+| Config File             | Parse Field           | Module =                |
+| ----------------------- | --------------------- | ----------------------- |
+| `pnpm-workspace.yaml`   | `packages:` array     | Each resolved glob path |
+| `package.json` (root)   | `"workspaces"` field  | Each resolved glob path |
+| `lerna.json`            | `"packages"` array    | Each resolved path      |
+| `Cargo.toml` (root)     | `[workspace] members` | Each member path        |
+| `settings.gradle(.kts)` | `include(...)`        | Each subproject dir     |
+| `pom.xml` (root)        | `<modules>` elements  | Each module dir         |
+| `go.work`               | `use (...)`           | Each module dir         |
 
 ### Phase 2: Conventional Directories (confidence: 0.6–0.8)
 
-| Pattern | Signal |
-|---------|--------|
-| `packages/*/package.json` | JS/TS monorepo packages |
-| `apps/*/` with build config | Application packages |
-| `services/*/Dockerfile` | Microservices |
-| `frontend/` + `backend/` | Client/server split |
-| `src/client/` + `src/server/` | Co-located client/server |
-| `docker-compose.yml` with multiple `build:` | Multi-service |
+| Pattern                                     | Signal                   |
+| ------------------------------------------- | ------------------------ |
+| `packages/*/package.json`                   | JS/TS monorepo packages  |
+| `apps/*/` with build config                 | Application packages     |
+| `services/*/Dockerfile`                     | Microservices            |
+| `frontend/` + `backend/`                    | Client/server split      |
+| `src/client/` + `src/server/`               | Co-located client/server |
+| `docker-compose.yml` with multiple `build:` | Multi-service            |
 
 ### Phase 3: Fallback
 
@@ -103,6 +193,7 @@ Entire repository = single module.
 ### Code Type Patterns
 
 **Auth/Security/Crypto (codeType=4):**
+
 ```
 \b(bcrypt|argon2|scrypt|pbkdf2)\b
 \b(jwt|jsonwebtoken|jose)\b
@@ -116,6 +207,7 @@ Entire repository = single module.
 ```
 
 **API/DB (codeType=3):**
+
 ```
 \b(app\.(get|post|put|delete|patch|use)\s*\()
 \b(@(Get|Post|Put|Delete|Patch)Mapping)
@@ -128,6 +220,7 @@ Entire repository = single module.
 ### Data Sensitivity Patterns
 
 **PHI/PCI (data=4):**
+
 ```
 \b(hipaa|phi|protected.health|health.record|medical.record)\b
 \b(pci|pci.dss|credit.card|card.number|cvv|cvc)\b
@@ -136,6 +229,7 @@ Entire repository = single module.
 ```
 
 **Sensitive PII (data=3):**
+
 ```
 \b(ssn|social.security.number|social_security)\b
 \b(passport.number|driver.?license|national.?id)\b
@@ -144,6 +238,7 @@ Entire repository = single module.
 ```
 
 **General PII (data=2):**
+
 ```
 \b(email|first.?name|last.?name|full.?name|phone.?number)\b
 \b(date.?of.?birth|dob|birth.?date|address|zip.?code)\b
@@ -153,11 +248,13 @@ Entire repository = single module.
 ### Deployment/Regulatory Patterns
 
 **Regulated (deployment>=3):**
+
 ```
 \b(HIPAA|PCI.DSS|SOC.?2|GDPR|FedRAMP|FISMA|NIST)\b
 ```
 
 **Safety-critical (deployment=4):**
+
 ```
 \b(DO.?178|IEC.?61508|ISO.?26262|EN.?50128)\b
 \b(SIL|DAL|ASIL|safety.?integrity|safety.?critical)\b
@@ -166,25 +263,25 @@ Entire repository = single module.
 
 ### Language Detection (file extensions)
 
-| Score | Extensions |
-|-------|-----------|
-| 0 | `.rs` |
-| 1 | `.ts`, `.tsx`, `.java`, `.go`, `.kt`, `.kts`, `.scala`, `.swift` |
-| 2 | `.py`, `.js`, `.jsx`, `.rb`, `.php`, `.lua`, `.pl`, `.ex`, `.exs` |
-| 3 | `.cs` (check for `unsafe` keyword → 3, else → 1) |
-| 4 | `.c`, `.h`, `.cpp`, `.cc`, `.cxx`, `.hpp`, `.asm`, `.s` |
+| Score | Extensions                                                        |
+| ----- | ----------------------------------------------------------------- |
+| 0     | `.rs`                                                             |
+| 1     | `.ts`, `.tsx`, `.java`, `.go`, `.kt`, `.kts`, `.scala`, `.swift`  |
+| 2     | `.py`, `.js`, `.jsx`, `.rb`, `.php`, `.lua`, `.pl`, `.ex`, `.exs` |
+| 3     | `.cs` (check for `unsafe` keyword → 3, else → 1)                  |
+| 4     | `.c`, `.h`, `.cpp`, `.cc`, `.cxx`, `.hpp`, `.asm`, `.s`           |
 
 ---
 
 ## Auto-Detection Confidence Levels
 
-| Dimension | Confidence | User Confirmation Needed? |
-|-----------|-----------|--------------------------|
-| codeType | 0.7–0.85 | Only if score <= 2 |
-| language | 0.85–0.95 | Rarely |
-| deployment | 0.2–0.5 | **Always** |
-| data | 0.5–0.7 | Usually (confirm >= 2) |
-| blastRadius | 0.1–0.3 | **Always** |
+| Dimension   | Confidence | User Confirmation Needed? |
+| ----------- | ---------- | ------------------------- |
+| codeType    | 0.7–0.85   | Only if score <= 2        |
+| language    | 0.85–0.95  | Rarely                    |
+| deployment  | 0.2–0.5    | **Always**                |
+| data        | 0.5–0.7    | Usually (confirm >= 2)    |
+| blastRadius | 0.1–0.3    | **Always**                |
 
 ---
 
@@ -192,71 +289,71 @@ Entire repository = single module.
 
 ### Tier 1 — Automated Gates (always active)
 
-| Measure | Type | Tools |
-|---------|------|-------|
-| Linter & Formatter | deterministic | ESLint, Prettier, Ruff, Black |
-| Type Checking | deterministic | TypeScript strict, mypy |
-| Pre-Commit Hooks | deterministic | husky + lint-staged, pre-commit framework |
-| Dependency Check | deterministic | npm audit, pip-audit, cargo audit |
-| CI Build & Unit Tests | deterministic | GitHub Actions, Jenkins, GitLab CI |
+| Measure               | Type          | Tools                                     |
+| --------------------- | ------------- | ----------------------------------------- |
+| Linter & Formatter    | deterministic | ESLint, Prettier, Ruff, Black             |
+| Type Checking         | deterministic | TypeScript strict, mypy                   |
+| Pre-Commit Hooks      | deterministic | husky + lint-staged, pre-commit framework |
+| Dependency Check      | deterministic | npm audit, pip-audit, cargo audit         |
+| CI Build & Unit Tests | deterministic | GitHub Actions, Jenkins, GitLab CI        |
 
 **Detection signals for existing mitigations:**
 
-| Measure | Config Files |
-|---------|-------------|
-| Linter | `.eslintrc*`, `ruff.toml`, `.pylintrc`, `lint` script in package.json |
-| Formatter | `.prettierrc*`, `rustfmt.toml`, `black` in pyproject.toml |
-| Type Checking | `tsconfig.json` (strict: true), `mypy.ini`, `[mypy]` in pyproject.toml |
-| Pre-Commit | `.pre-commit-config.yaml`, `.husky/`, `lint-staged` in package.json |
-| Dependency Check | `audit` in CI workflows, `safety` / `pip-audit` in requirements |
-| CI/CD | `.github/workflows/`, `Jenkinsfile`, `.gitlab-ci.yml` |
+| Measure          | Config Files                                                           |
+| ---------------- | ---------------------------------------------------------------------- |
+| Linter           | `.eslintrc*`, `ruff.toml`, `.pylintrc`, `lint` script in package.json  |
+| Formatter        | `.prettierrc*`, `rustfmt.toml`, `black` in pyproject.toml              |
+| Type Checking    | `tsconfig.json` (strict: true), `mypy.ini`, `[mypy]` in pyproject.toml |
+| Pre-Commit       | `.pre-commit-config.yaml`, `.husky/`, `lint-staged` in package.json    |
+| Dependency Check | `audit` in CI workflows, `safety` / `pip-audit` in requirements        |
+| CI/CD            | `.github/workflows/`, `Jenkinsfile`, `.gitlab-ci.yml`                  |
 
 ### Tier 2 — Extended Assurance
 
-| Measure | Type | Tools |
-|---------|------|-------|
-| SAST | deterministic | Semgrep, CodeQL |
-| AI Code Review | probabilistic | CodeRabbit, Copilot Review |
-| Property-Based Tests | probabilistic | fast-check, Hypothesis |
-| SonarQube Quality Gate | deterministic | SonarQube, SonarCloud |
-| Sampling Review (~20%) | organizational | PR review policy |
+| Measure                | Type           | Tools                      |
+| ---------------------- | -------------- | -------------------------- |
+| SAST                   | deterministic  | Semgrep, CodeQL            |
+| AI Code Review         | probabilistic  | CodeRabbit, Copilot Review |
+| Property-Based Tests   | probabilistic  | fast-check, Hypothesis     |
+| SonarQube Quality Gate | deterministic  | SonarQube, SonarCloud      |
+| Sampling Review (~20%) | organizational | PR review policy           |
 
 **Detection signals:**
 
-| Measure | Config Files |
-|---------|-------------|
-| SAST | `semgrep.yml` in CI, `codeql-analysis.yml`, `.semgrep/` |
-| SonarQube | `sonar-project.properties`, sonar step in CI |
-| Property-Based Tests | `fast-check` / `hypothesis` in dependencies |
+| Measure              | Config Files                                            |
+| -------------------- | ------------------------------------------------------- |
+| SAST                 | `semgrep.yml` in CI, `codeql-analysis.yml`, `.semgrep/` |
+| SonarQube            | `sonar-project.properties`, sonar step in CI            |
+| Property-Based Tests | `fast-check` / `hypothesis` in dependencies             |
 
 ### Tier 3 — Mandatory Measures for High Risk
 
-| Measure | Type | Tools |
-|---------|------|-------|
-| Mandatory Human Review | organizational | Branch protection rules |
-| Sandbox / Isolation | deterministic | Firecracker, Deno Sandbox |
-| Fuzzing | probabilistic | AFL++, cargo-fuzz, Fuzz4All |
-| Penetration Testing | organizational | Regular security audits |
-| Canary Deployments | deterministic | Gradual rollout + auto-rollback |
+| Measure                | Type           | Tools                            |
+| ---------------------- | -------------- | -------------------------------- |
+| Mandatory Human Review | organizational | Branch protection rules          |
+| Sandbox / Isolation    | deterministic  | Firecracker, Deno Sandbox        |
+| Fuzzing                | probabilistic  | AFL++, cargo-fuzz, Fuzz4All      |
+| Penetration Testing    | organizational | Regular security audits          |
+| Canary Deployments     | deterministic  | Gradual rollout + auto-rollback  |
 | PromptBOM / Provenance | organizational | Document model, prompt, approver |
 
 **Detection signals:**
 
-| Measure | Config Files |
-|---------|-------------|
+| Measure           | Config Files                                                     |
+| ----------------- | ---------------------------------------------------------------- |
 | Branch Protection | Check via `gh api repos/{owner}/{repo}/branches/main/protection` |
-| Fuzzing | `fuzz/` directory, `cargo-fuzz` in deps, AFL config |
+| Fuzzing           | `fuzz/` directory, `cargo-fuzz` in deps, AFL config              |
 
 ### Tier 4 — Critical (Severely Restrict AI Use)
 
-| Measure | Type | Tools |
-|---------|------|-------|
-| Formal Verification | deterministic | Dafny, TLA+, SPARK |
+| Measure                     | Type           | Tools                             |
+| --------------------------- | -------------- | --------------------------------- |
+| Formal Verification         | deterministic  | Dafny, TLA+, SPARK                |
 | Independent Re-Verification | organizational | Separate team (per DO-178C DAL A) |
-| MC/DC Test Coverage | deterministic | Coverage tools with MC/DC support |
-| Contract-Based Design | deterministic | Pre/postconditions + invariants |
-| Certification Process | organizational | IEC 61508, DO-178C, ISO 26262 |
-| AI as Draft Aid Only | organizational | LLM proposes, human implements |
+| MC/DC Test Coverage         | deterministic  | Coverage tools with MC/DC support |
+| Contract-Based Design       | deterministic  | Pre/postconditions + invariants   |
+| Certification Process       | organizational | IEC 61508, DO-178C, ISO 26262     |
+| AI as Draft Aid Only        | organizational | LLM proposes, human implements    |
 
 ---
 
@@ -270,24 +367,33 @@ Entire repository = single module.
 _Generated by `/risk-assess` on YYYY-MM-DD_
 
 ### Module: {module-name}
-| Dimension | Score | Level | Evidence |
-|-----------|-------|-------|----------|
-| Code Type | N | {level} | {files/patterns found} |
-| Language | N | {level} | {file counts by extension} |
-| Deployment | N | {level} | {config hints or user input} |
-| Data Sensitivity | N | {level} | {patterns found or user input} |
-| Blast Radius | N | {level} | {user input} |
 
-**Tier: N — {label}** (determined by {dimension} = {score})
+**LLM Runtime Integration:** L{N} ({name}) — {evidence or "user input: no runtime LLM use"}
+
+| Dimension        | Score | Level   | Evidence                       |
+| ---------------- | ----- | ------- | ------------------------------ |
+| Code Type        | N     | {level} | {files/patterns found}         |
+| Language         | N     | {level} | {file counts by extension}     |
+| Deployment       | N     | {level} | {config hints or user input}   |
+| Data Sensitivity | N     | {level} | {patterns found or user input} |
+| Blast Radius     | N     | {level} | {user input}                   |
+
+**Tier: N — {label}** (determined by {dimension} = {score}{, lifted to Tier N by LLM Runtime L{N} | if modifier applied})
 ```
+
+If the LLM Runtime modifier lifted the tier, make that explicit in the determining-dimension note:
+
+- Without modifier: `(determined by Code Type = 3)`
+- With modifier: `(determined by Code Type = 2, lifted to Tier 4 by LLM Runtime L4 — Agentic)`
 
 ### Per-Module Mitigation Status
 
 ```markdown
 ### Mitigations: {module-name} (Tier N)
-| Measure | Status | Details |
-|---------|--------|---------|
-| {name} | {status-emoji} {status} | {config file or note} |
+
+| Measure | Status                  | Details               |
+| ------- | ----------------------- | --------------------- |
+| {name}  | {status-emoji} {status} | {config file or note} |
 ```
 
 Status values: `Vorhanden/Present`, `Eingerichtet/Set up`, `Ausstehend/Pending`, `N/A`

--- a/src/components/RadarChart.jsx
+++ b/src/components/RadarChart.jsx
@@ -118,6 +118,7 @@ export default function RadarChart({
   size = 460,
   determiningKey = null,
   registerUpdater = null,
+  llmRuntimeLevel = 0,
 }) {
   // Safe fallbacks to prevent math from crashing if data is missing
   const safeDims = dimensions || [];
@@ -130,7 +131,12 @@ export default function RadarChart({
   const n = safeDims.length || 1; // prevents division by zero
   const angStep = 360 / n;
 
-  const ti = getTierIndex(safeVals);
+  // Ref mirrors the prop so the rAF-driven registerUpdater closure
+  // can read the current level without re-binding the callback.
+  const llmRuntimeLevelRef = useRef(llmRuntimeLevel);
+  llmRuntimeLevelRef.current = llmRuntimeLevel;
+
+  const ti = getTierIndex(safeVals, llmRuntimeLevel);
   const tc = TIER_BG[ti] || "#6b7280";
 
   const [tooltip, setTooltip] = useState(null);
@@ -150,7 +156,7 @@ export default function RadarChart({
     registerUpdater((newValues) => {
       if (!mountedRef.current) return;
       const dims = dimensionsRef.current;
-      const newTi = getTierIndex(newValues);
+      const newTi = getTierIndex(newValues, llmRuntimeLevelRef.current);
       const newTc = TIER_BG[newTi] || "#6b7280";
       const newRiskPts = dims.map((d, i) =>
         polarToCartesian(cx, cy, (maxR / levels) * (newValues[d.key] + 1), i * angStep),

--- a/src/components/RiskRadar.jsx
+++ b/src/components/RiskRadar.jsx
@@ -20,6 +20,15 @@ export default function RiskRadar() {
   // React state holds only the final integer values (for tier badge, level labels etc.)
   const [values, setValues] = useState({ codeType: 0, language: 1, deployment: 0, data: 0, blastRadius: 0 });
 
+  // LLM Runtime Integration Level (0=none, 1=classify, 2=generate, 3=tools, 4=agentic)
+  // Cross-cutting modifier — at L3+ it pushes the effective tier floor up.
+  const [llmRuntimeLevel, setLlmRuntimeLevelState] = useState(0);
+  const llmRuntimeLevelRef = useRef(0);
+  const setLlmRuntimeLevel = useCallback((level) => {
+    llmRuntimeLevelRef.current = level;
+    setLlmRuntimeLevelState(level);
+  }, []);
+
   // Animated float values live in a ref — updated every rAF frame
   // Both sliders and RadarChart read from this ref via their own refs
   const floatValuesRef = useRef({ ...values });
@@ -88,7 +97,7 @@ export default function RiskRadar() {
     roundedValues[k] = Math.round(values[k]);
   });
 
-  const ti = getTierIndex(roundedValues);
+  const ti = getTierIndex(roundedValues, llmRuntimeLevel);
   const tier = t.tiers[ti];
   const tc = TIER_BG[ti];
 
@@ -162,10 +171,51 @@ export default function RiskRadar() {
           <RadarChart
             values={values}
             dimensions={t.dimensions}
+            llmRuntimeLevel={llmRuntimeLevel}
             registerUpdater={(fn) => {
               chartValuesRef.current = fn;
             }}
           />
+        </div>
+
+        {/* LLM Runtime Integration Modifier */}
+        <div className={styles.llmRuntime}>
+          <div className={styles.llmRuntimeLabel}>{t.llmRuntime.label}</div>
+          <div className={styles.llmRuntimeLevels}>
+            {[0, 1, 2, 3, 4].map((lvl) => {
+              const isActive = llmRuntimeLevel === lvl;
+              const levelInfo = t.llmRuntime.levels[lvl];
+              return (
+                <button
+                  key={lvl}
+                  onClick={() => setLlmRuntimeLevel(lvl)}
+                  className={styles.llmRuntimeBtn}
+                  title={levelInfo.desc}
+                  style={{
+                    border: isActive ? `2px solid ${tc}` : "1px solid var(--border)",
+                    background: isActive ? `${tc}22` : "var(--bg-card)",
+                    color: isActive ? "var(--text-heading)" : "var(--text-muted)",
+                    fontWeight: isActive ? 700 : 500,
+                  }}
+                >
+                  L{lvl}
+                  <span className={styles.llmRuntimeBtnLabel}>{levelInfo.short}</span>
+                </button>
+              );
+            })}
+          </div>
+          {llmRuntimeLevel >= 3 && (
+            <div className={styles.llmRuntimeCallout} style={{ borderLeft: `3px solid ${tc}` }}>
+              <strong>{t.llmRuntime.calloutTitle}</strong> {t.llmRuntime.calloutBody}
+              <div className={styles.llmRuntimeLinks}>
+                {t.llmRuntime.frameworks.map((fw) => (
+                  <a key={fw.name} href={fw.url} target="_blank" rel="noopener">
+                    {fw.name}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Tier badge */}

--- a/src/components/RiskRadar.jsx
+++ b/src/components/RiskRadar.jsx
@@ -147,11 +147,15 @@ export default function RiskRadar() {
       {/* Presets */}
       <div className={styles.presets}>
         {t.presets.map((p) => {
-          const active = JSON.stringify(roundedValues) === JSON.stringify(p.values);
+          const presetLevel = p.llmRuntimeLevel ?? 0;
+          const active = JSON.stringify(roundedValues) === JSON.stringify(p.values) && llmRuntimeLevel === presetLevel;
           return (
             <button
               key={p.name}
-              onClick={() => animateTo(p.values)}
+              onClick={() => {
+                setLlmRuntimeLevel(presetLevel);
+                animateTo(p.values);
+              }}
               className={styles.presetBtn}
               style={{
                 border: active ? `2px solid ${tc}` : "1px solid var(--border)",

--- a/src/components/RiskRadar.module.css
+++ b/src/components/RiskRadar.module.css
@@ -83,6 +83,94 @@
   max-width: 500px; /* ← change only this to resize the chart */
 }
 
+/* ── LLM Runtime Integration Modifier ───────────────────────────────────── */
+
+.llmRuntime {
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.llmRuntimeLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.llmRuntimeLevels {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.llmRuntimeBtn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 6px 10px;
+  min-width: 74px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.2s ease;
+}
+
+.llmRuntimeBtn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.15);
+}
+
+.llmRuntimeBtnLabel {
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  opacity: 0.85;
+}
+
+.llmRuntimeCallout {
+  background: var(--bg-card);
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-top: 4px;
+}
+
+.llmRuntimeCallout strong {
+  color: var(--text-primary);
+  display: block;
+  margin-bottom: 4px;
+}
+
+.llmRuntimeLinks {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.llmRuntimeLinks a {
+  color: var(--link);
+  text-decoration: none;
+  border-bottom: 1px solid var(--link-underline);
+  font-weight: 600;
+  font-size: 12px;
+  transition: border-color 0.2s ease;
+}
+
+.llmRuntimeLinks a:hover {
+  border-bottom-color: var(--link);
+}
+
 .tierBadge {
   display: inline-flex;
   align-items: center;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -355,6 +355,25 @@ Dieses Framework bietet eine https://github.com/LLM-Coding/Semantic-Anchors?tab=
 *Organisatorisch* (orange) — Braucht Menschen, skaliert am schlechtesten. Deshalb erst ab Tier 2/3 eingeplant, und dort gezielt auf die riskantesten Änderungen fokussiert.`,
         },
         {
+          id: "llmRuntime",
+          title: "LLM Runtime Integration",
+          content: `Der Risk Radar bewertet primär den *geschriebenen Code*. Viele moderne Systeme nutzen LLMs aber auch *zur Laufzeit* — von einfacher Klassifikation bis zu agentic Systemen, die Code autonom ausführen. Diese Runtime-Nutzung bringt qualitativ andere Risiken mit sich als LLM-generierter Code und wird über den cross-cutting Modifier *LLM Runtime Integration* abgebildet.
+
+*Build-Time vs. Runtime* — LLM-Code ist ein Build-Time-Problem (Mitigation durch Linter, Review, SAST). LLM-Runtime ist ein Operational-Problem (Mitigation durch Sandboxing, Tool-Whitelists, Output-Filter, Prompt-Injection-Detection). Beide müssen gemeinsam betrachtet werden.
+
+*Die Eskalationsleiter:*
+
+* *L0 — Kein LLM:* Klassische Software ohne LLM zur Laufzeit.
+* *L1 — Klassifikation:* Passive Nutzung (Sentiment-Analyse, Intent-Erkennung, Embeddings). Risiken: Fehlklassifikation, Bias.
+* *L2 — Generativ:* Generative Ausgabe (Chat, Zusammenfassungen). Risiken: Halluzination, Prompt Injection auf Content.
+* *L3 — Tool Use:* Function Calling, LLM triggert Aktionen. Risiken: Prompt Injection → unautorisierte Aktionen, Jailbreaks.
+* *L4 — Agentic:* Autonome Loops, Code-Execution, Selbstmodifikation. Risiken: Prompt Injection → RCE, Daten-Exfiltration, Kostenlawinen, unkontrollierte Seiteneffekte.
+
+*Tier-Kopplung (harter Multiplier):* L3 erzwingt mindestens Tier 3, L4 mindestens Tier 4 — unabhängig von den fünf Code-Dimensionen. Ein Coding-Agent, der \`rm -rf\` ausführen könnte, ist per Definition safety-critical, selbst wenn der Blast Radius oberflächlich klein wirkt.
+
+*Ab L3 gilt: unser Mitigations-Katalog reicht nicht.* Die hier gelisteten Maßnahmen decken Build-Time-Risiken ab. Für Prompt Injection, Tool Sandboxing, Agentic Guardrails und Runtime-Monitoring verweisen wir auf spezialisierte Frameworks: https://owasp.org/www-project-top-10-for-large-language-model-applications/[OWASP LLM Top 10], https://unit42.paloaltonetworks.com/securing-vibe-coding-tools/[Palo Alto SHIELD], https://www.aikido.dev/blog/vibe-coding-security[Aikido VCAL], https://saif.google/secure-ai-framework[Google SAIF]. Diese Tools sind in ihrer Domäne reifer — der Radar ordnet nur ein und verweist weiter.`,
+        },
+        {
           id: "references",
           title: "Referenzen & Standards",
           content: `*Safety Standards:* https://www.perforce.com/blog/qac/what-iec-61508-safety-integrity-levels-sils[IEC 61508] (SIL), https://en.wikipedia.org/wiki/DO-178C[DO-178C] (DAL), https://en.wikipedia.org/wiki/ISO_26262[ISO 26262] (ASIL), https://www.euaiact.com/key-issue/3[EU AI Act]
@@ -754,6 +773,25 @@ This framework provides a https://github.com/LLM-Coding/Semantic-Anchors?tab=rea
 *Probabilistic* (purple) — Finds many issues but not all. AI code review, property-based testing, fuzzing. Increases detection rate but offers no guarantee.
 
 *Organizational* (orange) — Requires humans, scales worst. Therefore only introduced from Tier 2/3 onward, focused on the riskiest changes.`,
+        },
+        {
+          id: "llmRuntime",
+          title: "LLM Runtime Integration",
+          content: `The Risk Radar primarily assesses the *code being written*. However, many modern systems also use LLMs *at runtime* — from simple classification to agentic systems that execute code autonomously. This runtime use carries qualitatively different risks than LLM-generated code, captured by the cross-cutting *LLM Runtime Integration* modifier.
+
+*Build-time vs. runtime* — LLM code is a build-time problem (mitigation via linters, review, SAST). LLM runtime is an operational problem (mitigation via sandboxing, tool whitelists, output filters, prompt injection detection). Both must be considered together.
+
+*The escalation ladder:*
+
+* *L0 — No LLM:* Classical software, no LLM at runtime.
+* *L1 — Classify:* Passive use (sentiment analysis, intent detection, embeddings). Risks: misclassification, bias.
+* *L2 — Generate:* Generative output (chat, summaries). Risks: hallucination, prompt injection on content.
+* *L3 — Tool Use:* Function calling, LLM triggers actions. Risks: prompt injection → unauthorized actions, jailbreaks.
+* *L4 — Agentic:* Autonomous loops, code execution, self-modification. Risks: prompt injection → RCE, data exfiltration, runaway costs, uncontrolled side effects.
+
+*Tier coupling (hard multiplier):* L3 forces at least Tier 3, L4 forces at least Tier 4 — independent of the five code dimensions. A coding agent that could run \`rm -rf\` is by definition safety-critical, even if the surface-level blast radius seems small.
+
+*From L3 onward, our mitigation catalog is insufficient.* The measures listed here cover build-time risks. For prompt injection, tool sandboxing, agentic guardrails, and runtime monitoring, we defer to specialized frameworks: https://owasp.org/www-project-top-10-for-large-language-model-applications/[OWASP LLM Top 10], https://unit42.paloaltonetworks.com/securing-vibe-coding-tools/[Palo Alto SHIELD], https://www.aikido.dev/blog/vibe-coding-security[Aikido VCAL], https://saif.google/secure-ai-framework[Google SAIF]. These tools are more mature in their domain — the radar only classifies and points further.`,
         },
         {
           id: "references",

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -19,6 +19,28 @@ const T = {
     docsButton: "Dokumentation",
     closeButton: "Schließen",
     langSwitch: "EN",
+    llmRuntime: {
+      label: "LLM Runtime Integration",
+      levels: [
+        { short: "Kein LLM", desc: "Klassische Software ohne LLM zur Laufzeit" },
+        { short: "Klassifikation", desc: "Passive Nutzung: Sentiment, Intent, Embeddings" },
+        { short: "Generativ", desc: "Generative Ausgabe: Chat, Zusammenfassungen" },
+        { short: "Tool Use", desc: "Function Calling: LLM triggert Aktionen" },
+        { short: "Agentic", desc: "Autonome Loops, Code-Execution, Selbstmodifikation" },
+      ],
+      calloutTitle: "Runtime-Risiken außerhalb unseres Katalogs.",
+      calloutBody:
+        "Die Mitigationen hier decken Build-Time-Risiken ab. Für Prompt Injection, Tool Sandboxing und Agentic Guardrails siehe spezialisierte Frameworks:",
+      frameworks: [
+        {
+          name: "OWASP LLM Top 10",
+          url: "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+        },
+        { name: "Palo Alto SHIELD", url: "https://unit42.paloaltonetworks.com/securing-vibe-coding-tools/" },
+        { name: "Aikido VCAL", url: "https://www.aikido.dev/blog/vibe-coding-security" },
+        { name: "Google SAIF", url: "https://saif.google/secure-ai-framework" },
+      ],
+    },
     typeBadges: {
       deterministic: "Deterministisch",
       probabilistic: "Probabilistisch",
@@ -383,6 +405,28 @@ Quellcode der Skills: https://github.com/LLM-Coding/vibe-coding-risk-radar/tree/
     docsButton: "Documentation",
     closeButton: "Close",
     langSwitch: "DE",
+    llmRuntime: {
+      label: "LLM Runtime Integration",
+      levels: [
+        { short: "No LLM", desc: "Classical software, no LLM at runtime" },
+        { short: "Classify", desc: "Passive use: sentiment, intent, embeddings" },
+        { short: "Generate", desc: "Generative output: chat, summaries" },
+        { short: "Tool Use", desc: "Function calling: LLM triggers actions" },
+        { short: "Agentic", desc: "Autonomous loops, code execution, self-modification" },
+      ],
+      calloutTitle: "Runtime risks are outside our catalog.",
+      calloutBody:
+        "The mitigations here cover build-time risks. For prompt injection, tool sandboxing, and agentic guardrails, see specialized frameworks:",
+      frameworks: [
+        {
+          name: "OWASP LLM Top 10",
+          url: "https://owasp.org/www-project-top-10-for-large-language-model-applications/",
+        },
+        { name: "Palo Alto SHIELD", url: "https://unit42.paloaltonetworks.com/securing-vibe-coding-tools/" },
+        { name: "Aikido VCAL", url: "https://www.aikido.dev/blog/vibe-coding-security" },
+        { name: "Google SAIF", url: "https://saif.google/secure-ai-framework" },
+      ],
+    },
     typeBadges: {
       deterministic: "Deterministic",
       probabilistic: "Probabilistic",

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -121,6 +121,21 @@ const T = {
       { name: "Payment Service", values: { codeType: 4, language: 1, deployment: 2, data: 4, blastRadius: 3 } },
       { name: "Auth-Modul (Fintech)", values: { codeType: 4, language: 2, deployment: 2, data: 3, blastRadius: 3 } },
       { name: "Medizingerät-Firmware", values: { codeType: 4, language: 4, deployment: 4, data: 4, blastRadius: 4 } },
+      {
+        name: "Support-Chatbot",
+        values: { codeType: 2, language: 2, deployment: 2, data: 2, blastRadius: 1 },
+        llmRuntimeLevel: 2,
+      },
+      {
+        name: "RAG-Wissensassistent",
+        values: { codeType: 2, language: 2, deployment: 2, data: 2, blastRadius: 2 },
+        llmRuntimeLevel: 3,
+      },
+      {
+        name: "Coding-Agent",
+        values: { codeType: 3, language: 2, deployment: 2, data: 1, blastRadius: 3 },
+        llmRuntimeLevel: 4,
+      },
     ],
     mitigations: [
       {
@@ -507,6 +522,21 @@ Quellcode der Skills: https://github.com/LLM-Coding/vibe-coding-risk-radar/tree/
       { name: "Payment Service", values: { codeType: 4, language: 1, deployment: 2, data: 4, blastRadius: 3 } },
       { name: "Auth Module (Fintech)", values: { codeType: 4, language: 2, deployment: 2, data: 3, blastRadius: 3 } },
       { name: "Medical Device FW", values: { codeType: 4, language: 4, deployment: 4, data: 4, blastRadius: 4 } },
+      {
+        name: "Support Chatbot",
+        values: { codeType: 2, language: 2, deployment: 2, data: 2, blastRadius: 1 },
+        llmRuntimeLevel: 2,
+      },
+      {
+        name: "RAG Knowledge Assistant",
+        values: { codeType: 2, language: 2, deployment: 2, data: 2, blastRadius: 2 },
+        llmRuntimeLevel: 3,
+      },
+      {
+        name: "Coding Agent",
+        values: { codeType: 3, language: 2, deployment: 2, data: 1, blastRadius: 3 },
+        llmRuntimeLevel: 4,
+      },
     ],
     mitigations: [
       {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,9 @@
-export function getTierIndex(values) {
+export function getTierIndex(values, llmRuntimeLevel = 0) {
   const mx = Math.max(...Object.values(values));
-  return mx <= 1 ? 0 : mx <= 2 ? 1 : mx <= 3 ? 2 : 3;
+  const base = mx <= 1 ? 0 : mx <= 2 ? 1 : mx <= 3 ? 2 : 3;
+  // LLM Runtime Modifier: L3 → min Tier 3 (index 2), L4 → min Tier 4 (index 3)
+  const floor = llmRuntimeLevel >= 4 ? 3 : llmRuntimeLevel >= 3 ? 2 : 0;
+  return Math.max(base, floor);
 }
 
 export function polarToCartesian(cx, cy, r, angleDeg) {


### PR DESCRIPTION
## Summary

Adds a cross-cutting **LLM Runtime Integration** modifier (L0–L4) that captures how the software uses LLMs *at runtime*, separate from the 5 code dimensions. This addresses a gap in the framework: the 5 dimensions describe the written code, but agentic systems (Claude Code, RAG assistants, chatbots) have qualitatively different runtime risks — prompt injection, unauthorized tool calls, code execution.

Closes #20. Implementation plan & decisions documented in the [issue comments](https://github.com/LLM-Coding/vibe-coding-risk-radar/issues/20).

## What's new

### UI (between chart and tier badge)
- Pill-button row L0–L4 with level descriptions
- Callout box at L3+ pointing to OWASP LLM Top 10, Palo Alto SHIELD, Aikido VCAL, Google SAIF

### Tier logic — hard multiplier
- L3 forces **at least Tier 3**, L4 forces **at least Tier 4**, regardless of the 5 code dimensions
- Rationale: An agent that can run \`rm -rf\` is safety-critical by definition

### New presets
- **Support Chatbot** → L2 (Tier 2)
- **RAG Knowledge Assistant** → L3 (Tier 3, lifted by modifier)
- **Coding Agent** → L4 (Tier 4, lifted by modifier)

Existing presets reset the modifier to L0 on click.

### Documentation sidebar
- New section *LLM Runtime Integration* (DE + EN) explaining build-time vs runtime, the escalation ladder, the tier multiplier, and framework references

### Skills integration
- \`shared/risk-model.md\`: escalation ladder, tier calculation with modifier, grep patterns for LLM SDKs (anthropic, openai, langchain, @ai-sdk/*), agentic indicators, sandbox libraries
- \`/risk-assess\`: Step 2f (detection), Step 3d (always ask to confirm), Step 4a (tier with lift note)
- \`/risk-mitigate\`: Step 1 parses \`llmRuntimeLevel\`, new Step 3b with L3+ callout pointing to specialized frameworks; does not install runtime mitigations (architectural decisions belong with the user)

## Commits (5 phases)

| Phase | Commit | Scope |
|-------|--------|-------|
| 1+2 | Data model + tier logic + UI | \`utils.js\`, \`RiskRadar.jsx\`, \`RadarChart.jsx\`, \`i18n.js\`, CSS |
| 3 | Agentic presets + reset | \`i18n.js\`, \`RiskRadar.jsx\` |
| 4 | Docs sidebar section | \`i18n.js\` |
| 5 | Skills integration | 3 skill files |

## Design decisions

- **Modifier, not 6th dimension** — keeps MECE intact, avoids conflating \"code written\" with \"what code does at runtime\"
- **Hard multiplier (not additive)** — L4 is safety-critical regardless of blast radius, not proportional
- **Fixed dark tooltip colors** kept from prior PR
- **Framework links, not own catalog** — OWASP/SHIELD/VCAL/SAIF cover agentic risks more maturely; we classify and defer

## Test plan

- [x] Build passes (\`npm run build\`)
- [x] Verified in browser (Edge headless): L4 lifts Tier to 4, L3 to 3, L0–L2 don't lift
- [x] Verified: Coding Agent preset → Tier 4 + callout
- [x] Verified: CSS Landing Page resets L0 after Coding Agent L4
- [x] Verified: Support Chatbot → L2 (Generate)
- [x] Verified: Docs sidebar renders new section in DE and EN with framework links
- [ ] Manual review of skills updates (no runtime behavior to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LLM Runtime Integration dimension to assess risks from LLM SDK usage and agentic code patterns.
  * Introduced interactive runtime level selector (L0–L4) in the risk radar with real-time tier recalculation.
  * Added runtime-specific risk callouts and mitigation guidance for high-integration scenarios.
  * Expanded preset configurations to include Support-Chatbot, RAG Knowledge Assistant, and Coding-Agent archetypes.

* **Documentation**
  * Updated risk model and workflow documentation to reflect LLM runtime assessment integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->